### PR TITLE
feat: Criado arquivo que instala NGINX, configura proxy reverso para …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,14 +42,6 @@ resource "aws_security_group" "backendchallenge_sg" {
     cidr_blocks      = ["0.0.0.0/0"]
   }
 
-  ingress {
-    description      = "Allow HTTPS"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-  }
-
   # Outbound rules (allow all by default)
   egress {
     description      = "Allow all outbound traffic"

--- a/playbooks/configure-nginx.yml
+++ b/playbooks/configure-nginx.yml
@@ -1,0 +1,47 @@
+- name: Configure NGINX reverse proxy
+  hosts: all
+  become: yes
+  vars:
+    dotnet_port: 5000
+
+  tasks:
+    - name: Install NGINX
+      ansible.builtin.apt:
+        name: nginx
+        state: present
+        update_cache: yes
+
+    - name: Ensure NGINX is started and enabled
+      ansible.builtin.service:
+        name: nginx
+        state: started
+        enabled: yes
+
+    - name: Configure NGINX reverse proxy
+      ansible.builtin.copy:
+        dest: /etc/nginx/sites-available/default
+        content: |
+          server {
+              listen 80;
+
+              server_name _;
+
+              location / {
+                  proxy_pass         http://localhost:{{ dotnet_port }};
+                  proxy_http_version 1.1;
+                  proxy_set_header   Upgrade $http_upgrade;
+                  proxy_set_header   Connection keep-alive;
+                  proxy_set_header   Host $host;
+                  proxy_cache_bypass $http_upgrade;
+              }
+          }
+
+    - name: Test NGINX configuration
+      ansible.builtin.command: nginx -t
+      register: nginx_test
+      failed_when: nginx_test.rc != 0
+
+    - name: Reload NGINX
+      ansible.builtin.service:
+        name: nginx
+        state: reloaded

--- a/playbooks/deploy-dotnet.yml
+++ b/playbooks/deploy-dotnet.yml
@@ -32,7 +32,8 @@
     - name: Stop any running .NET application
       become: yes
       ansible.builtin.shell: pkill -f 'Back-End_Challenge_20210221.dll' || true
-      ignore_errors: true
+      register: pkill_result
+      failed_when: false
 
     - name: Wait to ensure the process was stopped
       ansible.builtin.pause:


### PR DESCRIPTION
…redirecionar as requisições recebidas na porta 80 para porta 5000 (porta onde aplicação .NET está sendo executada na máquina EC2), e reinicia o servidor para aplicar as configurações

- Pelo fato de HTTPS não estar sendo utilizado neste exemplo, retirada regra de entrada na máquina EC2 na porta 443 (padrão HTTPS);
- A fim de melhor organização, criada pasta para os playbooks, criado playbook específico para configuração do NGINX, e renomeado playbook de publicação da aplicação .NET;
- Para evitar exibição de erro na tarefa ignorado, aprimorada tarefa de encerrar processo já existente de aplicação .NET, para execução da nova instância;